### PR TITLE
Change serializer 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "jbuilder"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
-gem "fast_jsonapi"
+gem "jsonapi-serializer"
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,8 +77,6 @@ GEM
       reline (>= 0.2.7)
     digest (3.1.0)
     erubi (1.10.0)
-    fast_jsonapi (1.5)
-      activesupport (>= 4.2)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.10.0)
@@ -92,6 +90,8 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -188,9 +188,9 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   debug
-  fast_jsonapi
   importmap-rails
   jbuilder
+  jsonapi-serializer
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.3)

--- a/app/serializers/airline_serializer.rb
+++ b/app/serializers/airline_serializer.rb
@@ -1,5 +1,5 @@
 class AirlineSerializer
-  include FastJsonapi::ObjectSerializer
+  include JSONAPI::Serializer
   attributes :name, :image_url, :slug
 
   has_many :reviews

--- a/app/serializers/review_serializer.rb
+++ b/app/serializers/review_serializer.rb
@@ -1,4 +1,4 @@
 class ReviewSerializer
-  include FastJsonapi::ObjectSerializer
+  include JSONAPI::Serializer
   attributes :title, :description, :score, :airline_id
 end


### PR DESCRIPTION
Change from `fast_jsonapi` to `jsonapi-serializer` because `fast_jsonapi` is no longer maintained.

Refer to pull request https://github.com/Michelle-Lohwt/open-flights/pull/5